### PR TITLE
Fixed Apple IAP not listed

### DIFF
--- a/index.markdown
+++ b/index.markdown
@@ -212,6 +212,7 @@ Interested in [creating a plugin][native.plugin]? Please see our [Plugins][nativ
 </div>
 
 * [Amazon IAP][plugin.amazon-iap-v2]
+* [Apple IAP][plugin.apple-iap]
 * [Google IAP][plugin.google-iap-v3]
 
 <div class="clear"></div>


### PR DESCRIPTION
Fixed something I missed on the previous pull #4 . This fixes Apple IAP being listed on sidebar but not on the main window.